### PR TITLE
Changing from '==' check to '>=' in comparing elapsedTime to timeoutLimit

### DIFF
--- a/conditionwatcher/src/main/java/com/azimolabs/conditionwatcher/ConditionWatcher.java
+++ b/conditionwatcher/src/main/java/com/azimolabs/conditionwatcher/ConditionWatcher.java
@@ -40,7 +40,7 @@ public class ConditionWatcher {
                 Thread.sleep(getInstance().watchInterval);
             }
 
-            if (elapsedTime == getInstance().timeoutLimit) {
+            if (elapsedTime >= getInstance().timeoutLimit) {
                 status = TIMEOUT;
                 break;
             }


### PR DESCRIPTION
I didn't see any logic that would forcefully align the interval with the timeoutLimit so I think its safer to have the '>=' than a '==' comparison