### PR TITLE
Replace compile with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You don't have to be worried of unexpected behaviours. `ConditionWatcher` will s
 
 ```gradle
 dependencies {
-  androidTestCompile 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'
+  androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'
 }
 ```
 


### PR DESCRIPTION
I've replaced deprecated configurations in README.md. Configurations 'androidTestCompile' is obsolete and has been replaced with 'androidTestImplementation' and 'androidTestApi'.